### PR TITLE
Add configurable offset (e.g. for german shutter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ This card allows to open, close or set a shutter to the opening rate you want.
 | buttons_position | string | False | `left` | Set buttons on `left` or on `right` of the shutter
 | title_position | string | False | `top` | Set title on `top` or on `bottom` of the shutter
 | invert_percentage | boolean | False | `false` | Set it to `true` if your shutter is 100% when it is closed, and 0% when it is opened
+| offset | integer | False | 0 | See [Offset configuration](#offset-configuration)
 
 _Remark : you can also just give the entity ID (without to specify `entity:`) if you don't need to specify the other configurations._
+
+#### Offset configuration
+
+Some shutter won't run relative to the cards shutter (e.g. the german _Rolladen_) and need some offset.
+Easiest way is to close the shutter to the desired 0% open position and take the shown value (e.g. `15`) as offset configuration.
+
+_Remark : Setting the shutter to real 0% is only possible by pressing the `down` button then._
 
 ### Sample
 

--- a/hass-shutter-card.js
+++ b/hass-shutter-card.js
@@ -112,6 +112,10 @@ class ShutterCard extends HTMLElement {
           
           let percentagePosition = (newPosition - _this.minPosition) * 100 / (_this.maxPosition - _this.minPosition);
           
+          if (entity && entity.offset)
+            percentagePosition = percentagePosition  * ((100 - entity.offset) / 100);
+          
+
           if (invertPercentage) {
             _this.updateShutterPosition(hass, entityId, percentagePosition);
           } else {
@@ -198,6 +202,7 @@ class ShutterCard extends HTMLElement {
       if (entity && entity.invert_percentage) {
         invertPercentage = entity.invert_percentage;
       }
+      const offset = (entity && entity.offset) ? entity.offset : false;
         
       const shutter = _this.card.querySelector('div[data-shutter="' + entityId +'"]');
       const slide = shutter.querySelector('.sc-shutter-selector-slide');
@@ -205,8 +210,15 @@ class ShutterCard extends HTMLElement {
         
       const state = hass.states[entityId];
       const friendlyName = (entity && entity.name) ? entity.name : state ? state.attributes.friendly_name : 'unknown';
-      const currentPosition = state ? state.attributes.current_position : 'unknown';
+      let currentPosition = state ? state.attributes.current_position : 'unknown';
       
+      if (offset){
+        if (currentPosition <= offset)
+          currentPosition = 0;
+        else
+          currentPosition = Math.round((currentPosition - offset) / ((100 - offset) / 100));
+      }
+
       shutter.querySelectorAll('.sc-shutter-label').forEach(function(shutterLabel) {
           shutterLabel.innerHTML = friendlyName;
       })


### PR DESCRIPTION
In Germany 🇩🇪 (and maybe some other countries too?) we call our shutter/cover/blinds _*Rollladen*_, and they seem to behave a little differently. 
If you never saw the german version, here is a quick video: https://youtu.be/PCudaPpwoAM?t=76

To sum it up, when the _Rollladen_ is closing, and touching the bottom position, it is not completely closed. The elements (_Rollladenstäbe_) are loosely connected and allow some light to get through (_Lichtschlitze_). After some additional movement in the closing direction, manually via a Belt (_Gurtband_) or electrical, it closes completely.

As the wife was complaining the Window (_Fenster_) was not looking like the real window I came up with this fix.

Also requested here: https://github.com/Deejayfool/hass-shutter-card/issues/24 