### PR TITLE
New [up|down|stop]_disabled_states config to control button disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This card allows to open, close or set a shutter to the opening rate you want.
 | always_percentage | boolean | False | `false` | If set to `true`, the end states (opened/closed) will be also as numbers (0 / 100 % ) instead of a text
 | shutter_width_px | int | False | `153` | Set shutter visualization width in px. You can make it thicker or narrower to fit your layout.
 | disable_end_buttons | boolean | False | `false` | If set to `true`, the end states (opened/closed) will also deactivate the buttons for that direction (i.e. the "up" button will be disabled when the shutters are fully open)
+| up_disabled_states | string list | False | empty list | Any state strings ('opening', 'open', etc.) added will disable the 'up' button when the cover is in any of the listed states.  This is instead of the disable_end_buttons option and can be combined with other *_disabled_states options.
+| down_disabled_states | string list | False | empty list | Any state strings ('closing', 'closed', etc.) added will disable the 'down' button when the cover is in any of the listed states.  This is instead of the disable_end_buttons option and can be combined with other *_disabled_states options.
+| stop_disabled_states | string list | False | empty list | Any state strings ('open', 'closed', etc.) added will disable the 'stop' button when the cover is in any of the listed states.  This is instead of the disable_end_buttons option and can be combined with other *_disabled_states options.
 
 _Remark : you can also just give the entity ID (without to specify `entity:`) if you don't need to specify the other configurations._
 

--- a/hass-shutter-card.js
+++ b/hass-shutter-card.js
@@ -291,6 +291,25 @@ class ShutterCard extends HTMLElement {
         disableEnd = entity.disable_end_buttons;
       }
 
+      let stateDisable = false;
+      let stopDisabledStates = [];
+      if (entity && entity.stop_disabled_states) {
+        stateDisable = true;
+        stopDisabledStates = entity.stop_disabled_states;
+      }
+
+      let upDisabledStates = [];
+      if (entity && entity.up_disabled_states) {
+        stateDisable = true;
+        upDisabledStates = entity.up_disabled_states;
+      }
+
+      let downDisabledStates = [];
+      if (entity && entity.down_disabled_states) {
+        stateDisable = true;
+        downDisabledStates = entity.down_disabled_states;
+      }
+
       const shutter = _this.card.querySelector('div[data-shutter="' + entityId +'"]');
       const slide = shutter.querySelector('.sc-shutter-selector-slide');
       const picker = shutter.querySelector('.sc-shutter-selector-picker');
@@ -312,25 +331,29 @@ class ShutterCard extends HTMLElement {
             visiblePosition = offset?Math.min(100, Math.round(currentPosition / offset * 100 )):currentPosition;
             positionText = _this.positionPercentToText(visiblePosition, invertPercentage, alwaysPercentage, hass);
             if (disableEnd) {
-              _this.changeButtonState(shutter, currentPosition, invertPercentage);
+              _this.changeButtonState(shutter, movementState, currentPosition, invertPercentage);
+            } else if (stateDisable) {
+              _this.changeButtonStateForState(shutter, movementState, stopDisabledStates, upDisabledStates, downDisabledStates);
             }
             if (visiblePosition == 100 && offset) {
               positionText += ' ('+ (100-Math.round(Math.abs(currentPosition-visiblePosition)/offset*100)) +' %)';
             }
           }
-          else  {
+          else {
             visiblePosition = offset?Math.max(0, Math.round((currentPosition - offset) / (100-offset) * 100 )):currentPosition;
             positionText = _this.positionPercentToText(visiblePosition, invertPercentage, alwaysPercentage, hass);
             if (disableEnd) {
-              _this.changeButtonState(shutter, currentPosition, invertPercentage);
+              _this.changeButtonState(shutter, movementState, currentPosition, invertPercentage);
+            } else if (stateDisable) {
+              _this.changeButtonStateForState(shutter, movementState, stopDisabledStates, upDisabledStates, downDisabledStates);
             }
             if (visiblePosition == 0 && offset) {
               positionText += ' ('+ (100-Math.round(Math.abs(currentPosition-visiblePosition)/offset*100)) +' %)';
             }
           }
-          
+
           shutterPosition.innerHTML = positionText;
-          
+
         })
 
         _this.setPickerPositionPercentage(currentPosition, picker, slide, invertPercentage, offset);
@@ -366,6 +389,19 @@ class ShutterCard extends HTMLElement {
         button.disabled = false;
       }) ;
     }
+  }
+  
+  changeButtonStateForState(shutter, movementState, stopDisabledStates, upDisabledStates, downDisabledStates) {
+    shutter.querySelectorAll('.sc-shutter-button-stop').forEach(function (button) {
+
+      button.disabled = stopDisabledStates.includes(movementState);
+    });
+    shutter.querySelectorAll('.sc-shutter-button-up').forEach(function (button) {
+      button.disabled = upDisabledStates.includes(movementState);
+    });
+    shutter.querySelectorAll('.sc-shutter-button-down').forEach(function (button) {
+      button.disabled = downDisabledStates.includes(movementState);
+    });
   }
 
   positionPercentToText(percent, inverted, alwaysPercentage, hass) {


### PR DESCRIPTION
This would be used instead of disable_end_buttons since it allows finer control.  The config could look something like:

```
    up_disabled_states:
      - open
      - opening
    down_disabled_states:
      - closed
      - closing
      - opening
    stop_disabled_states:
      - open
      - closed
      - closing
      - stopped
